### PR TITLE
Add README and require explicit IMAGE_REPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Swarm Cleanup
+
+`cleanup.sh` is a small Bash utility that removes unused Docker images and containers from a node. It works on standalone Docker hosts and Swarm nodes. When run on a Swarm manager it protects images that are in use by services.
+
+## Requirements
+
+- Bash
+- Docker CLI available in `PATH`
+- Docker daemon reachable (and Swarm mode if you want service protections)
+
+## Usage
+
+Provide the target repository via positional argument or `IMAGE_REPO` environment variable:
+
+```bash
+# using positional argument
+./cleanup.sh myorg/myimage
+
+# or using environment variable
+IMAGE_REPO=myorg/myimage ./cleanup.sh
+```
+
+Set `DRY_RUN=1` to preview deletions without removing anything:
+
+```bash
+IMAGE_REPO=myorg/myimage DRY_RUN=1 ./cleanup.sh
+```
+
+`RM_TIMEOUT` configures a timeout for each `docker rmi`/untag command (default `20s`).
+
+The script exits with an error if `IMAGE_REPO` is not specified.
+
+## Development
+
+Contributions are welcome. Please run `bash -n cleanup.sh` before submitting changes.
+
+## License
+
+This project is provided under the MIT License.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+# cleanup.sh - remove unused Docker images for a given repository
+#
+# Usage:
+#   IMAGE_REPO=myorg/myimage ./cleanup.sh
+#   ./cleanup.sh myorg/myimage
+#
+# Environment variables:
+#   DRY_RUN=1       Preview deletions without removing anything
+#   RM_TIMEOUT=20s  Timeout for docker rmi/untag commands
+
 # === CONFIG (overridable) ===
-# Repo to clean: CLI arg > ENV > default
-IMAGE_REPO="${1:-${IMAGE_REPO:-tanngoc93/feedmama}}"
+# Repo to clean: CLI arg > ENV (required)
+IMAGE_REPO="${1:-${IMAGE_REPO:-}}"
+if [[ -z "$IMAGE_REPO" ]]; then
+  echo "Error: IMAGE_REPO is required. Set IMAGE_REPO env or pass as first argument." >&2
+  exit 1
+fi
 # Dry-run: set to 1 to preview deletions (no actual removals)
 DRY_RUN="${DRY_RUN:-0}"
 # Max time for each docker rmi/untag command


### PR DESCRIPTION
## Summary
- document project usage and requirements in a new README
- add English usage comments in the cleanup script
- remove default image repo and require IMAGE_REPO to be provided

## Testing
- `bash -n cleanup.sh`
- `bash cleanup.sh` (fails: IMAGE_REPO is required)
- `IMAGE_REPO=myorg/myimage DRY_RUN=1 bash cleanup.sh` (fails: Docker daemon not reachable)


------
https://chatgpt.com/codex/tasks/task_e_68a749bd3798832b8899ac6d815d42af