### PR TITLE
Add Docker Swarm deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ IMAGE_REPO=myorg/myimage DRY_RUN=1 ./cleanup.sh
 
 The script exits with an error if `IMAGE_REPO` is not specified.
 
+## Running in Docker Swarm
+
+To clean up every node in a Swarm cluster you can deploy `cleanup.sh` as a
+one-shot global service. A sample stack file is provided at
+`docker/docker-cleaner-stack.yml`.
+
+1. Set the image repository you want to purge and deploy the stack:
+
+   ```bash
+   IMAGE_REPO=myorg/myimage docker stack deploy \
+     -c docker/docker-cleaner-stack.yml swarm-cleanup
+   ```
+
+   The service will run once on each node, remove unused images matching the
+   repository and then exit.
+
+2. After all tasks complete, remove the stack:
+
+   ```bash
+   docker stack rm swarm-cleanup
+   ```
+
+The stack file clones this repository on each node at run time so you do not
+need to pre-distribute the script.
+
 ## Development
 
 Contributions are welcome. Please run `bash -n cleanup.sh` before submitting changes.

--- a/docker/docker-cleaner-stack.yml
+++ b/docker/docker-cleaner-stack.yml
@@ -1,0 +1,26 @@
+services:
+  swarm_cleanup:
+    image: alpine:3.19
+    environment:
+      REPO_URL: "https://github.com/tanngoc93/swarm_cleanup.git"
+      REPO_DIR: "/tmp/swarm_cleanup"
+      SCRIPT: "cleanup.sh"
+      IMAGE_REPO: "${IMAGE_REPO}"
+    command: >
+      sh -c "
+        set -e;
+        echo '--- [Swarm Cleanup] running on node: '$$(hostname);
+        apk add --no-cache git bash docker-cli >/dev/null;
+        rm -rf $$REPO_DIR &&
+        git clone --depth=1 $$REPO_URL $$REPO_DIR;
+        chmod +x $$REPO_DIR/$$SCRIPT;
+        IMAGE_REPO=$$IMAGE_REPO bash $$REPO_DIR/$$SCRIPT;
+        echo '--- Done on node: '$$(hostname);
+        exit 0
+      "
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      mode: global
+      restart_policy:
+        condition: none


### PR DESCRIPTION
## Summary
- add stack file to run cleanup script across Swarm nodes
- document Swarm deployment instructions and stack usage

## Testing
- `bash -n cleanup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a74d0bc770832b94cd19618474fe90