### PR TITLE
Add swarm cleanup wrapper and update README

### DIFF
--- a/swarm_image_cleanup.sh
+++ b/swarm_image_cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+STACK_FILE="$(dirname "$0")/docker/docker-cleaner-stack.yml"
+STACK_NAME="cleanup"
+
+echo "🚀 Deploy cleanup stack..."
+RUN_AT=$(date +%s) IMAGE_REPO="${IMAGE_REPO}" docker stack deploy -c $STACK_FILE $STACK_NAME
+
+echo "⏳ Waiting for cleanup tasks..."
+while true; do
+  STATUS=$(docker service ps ${STACK_NAME}_swarm_cleanup \
+    --no-trunc --format "{{.CurrentState}}" 2>/dev/null | head -n1)
+
+  echo "State: $STATUS"
+
+  if [[ "$STATUS" == *"Complete"* ]] || [[ "$STATUS" == *"Shutdown"* ]]; then
+    echo "✅ Cleanup finished"
+    break
+  fi
+
+  if [[ "$STATUS" == *"Failed"* ]]; then
+    echo "❌ Cleanup failed"
+    break
+  fi
+
+  sleep 3
+done
+
+echo "🧹 Removing stack..."
+docker stack rm $STACK_NAME


### PR DESCRIPTION
## Summary
- add `swarm_image_cleanup.sh` wrapper to deploy the cleanup stack across all nodes and wait for completion
- document single-node, convenience script, and manual Swarm stack usage

## Testing
- `bash -n cleanup.sh && bash -n swarm_image_cleanup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a74e9fc730832ba31d17ea7797ce0f