### PR TITLE
Default cleanup stack variables with docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,14 @@ The script exits with an error if `IMAGE_REPO` is not specified.
 ## Deploying a stack
 
 `deploy_stack_with_cleanup.sh` deploys or updates a Docker Swarm stack and then runs the cleanup
-routine to remove unused images. It requires `IMAGE_REPO`, `STACK_NAME`, `STACK_FILE`,
-`CLEANUP_STACK_FILE`, and `CLEANUP_STACK_NAME` environment variables.
+routine to remove unused images. It requires `IMAGE_REPO`, `STACK_NAME`, and `STACK_FILE`
+environment variables. `CLEANUP_STACK_FILE` and `CLEANUP_STACK_NAME` are optional and
+default to `docker/docker-cleaner-stack.yml` and `swarm-cleanup` respectively.
 
 ```bash
 IMAGE_REPO=myorg/myimage \\
 STACK_NAME=feedmama \\
 STACK_FILE=/path/to/stack.yml \\
-CLEANUP_STACK_FILE=docker/docker-cleaner-stack.yml \\
-CLEANUP_STACK_NAME=swarm-cleanup \\
 ./deploy_stack_with_cleanup.sh
 ```
 
@@ -55,10 +54,10 @@ The repository also includes tooling to clean every node in a Swarm cluster.
 
 ### Option 1: Convenience script
 
-Use `scripts/swarm_cleanup.sh` to deploy a temporary stack, wait for all cleanup tasks to finish, and then remove the stack automatically. It requires `IMAGE_REPO`, `STACK_FILE`, and `STACK_NAME` environment variables:
+Use `scripts/swarm_cleanup.sh` to deploy a temporary stack, wait for all cleanup tasks to finish, and then remove the stack automatically. It requires `IMAGE_REPO` and accepts optional `STACK_FILE` and `STACK_NAME` variables:
 
 ```bash
-IMAGE_REPO=myorg/myimage STACK_FILE=docker/docker-cleaner-stack.yml STACK_NAME=swarm-cleanup ./scripts/swarm_cleanup.sh
+IMAGE_REPO=myorg/myimage ./scripts/swarm_cleanup.sh
 ```
 
 The stack file runs `scripts/docker_image_cleanup.sh` on each node.

--- a/deploy_stack_with_cleanup.sh
+++ b/deploy_stack_with_cleanup.sh
@@ -10,8 +10,8 @@
 #   LOG_FILE        - Output log (default: /var/log/deploy_${STACK_NAME}.log)
 #   LOCK_FILE       - PID lock file (default: /tmp/deploy_${STACK_NAME}.pid)
 #   CLEANUP_SCRIPT     - Script to run after deployment (default: ./scripts/swarm_cleanup.sh)
-#   CLEANUP_STACK_FILE - Stack file used by the cleanup script (required)
-#   CLEANUP_STACK_NAME - Stack name used by the cleanup script (required)
+#   CLEANUP_STACK_FILE - Stack file used by the cleanup script (default: ./docker/docker-cleaner-stack.yml)
+#   CLEANUP_STACK_NAME - Stack name used by the cleanup script (default: swarm-cleanup)
 
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 IMAGE_REPO="${IMAGE_REPO:-}"
@@ -21,11 +21,11 @@ LOG_FILE="${LOG_FILE:-/var/log/deploy_${STACK_NAME}.log}"
 LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}.pid}"
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/scripts/swarm_cleanup.sh}"
-CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-}"
-CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-}"
+CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$SCRIPT_DIR/docker/docker-cleaner-stack.yml}"
+CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-swarm-cleanup}"
 
-if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" || -z "$CLEANUP_STACK_FILE" || -z "$CLEANUP_STACK_NAME" ]]; then
-  echo "IMAGE_REPO, STACK_NAME, STACK_FILE, CLEANUP_STACK_FILE and CLEANUP_STACK_NAME must be set" >&2
+if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" ]]; then
+  echo "IMAGE_REPO, STACK_NAME and STACK_FILE must be set" >&2
   exit 1
 fi
 

--- a/scripts/swarm_cleanup.sh
+++ b/scripts/swarm_cleanup.sh
@@ -3,15 +3,21 @@ set -euo pipefail
 
 # Environment variables:
 #   IMAGE_REPO - Repository to clean (required)
-#   STACK_FILE - Path to the cleanup stack file (required)
-#   STACK_NAME - Name of the cleanup stack (required)
+#   STACK_FILE - Path to the cleanup stack file (default: ../docker/docker-cleaner-stack.yml)
+#   STACK_NAME - Name of the cleanup stack (default: swarm-cleanup)
 
-STACK_FILE="${STACK_FILE:-}"
-STACK_NAME="${STACK_NAME:-}"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+STACK_FILE="${STACK_FILE:-$SCRIPT_DIR/../docker/docker-cleaner-stack.yml}"
+STACK_NAME="${STACK_NAME:-swarm-cleanup}"
 IMAGE_REPO="${IMAGE_REPO:-}"
 
-if [[ -z "$IMAGE_REPO" || -z "$STACK_FILE" || -z "$STACK_NAME" ]]; then
-  echo "IMAGE_REPO, STACK_FILE and STACK_NAME must be set" >&2
+if [[ -z "$IMAGE_REPO" ]]; then
+  echo "IMAGE_REPO must be set" >&2
+  exit 1
+fi
+
+if [[ ! -f "$STACK_FILE" ]]; then
+  echo "Stack file not found: $STACK_FILE" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- provide default stack file and name for post-deploy cleanup
- default stack file and name for `swarm_cleanup.sh`
- document optional cleanup variables and streamlined usage

## Testing
- `bash -n deploy_stack_with_cleanup.sh scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7fae5de30832b88e2a3dd348375bb