### PR TITLE
Expose cleanup controls in stack

### DIFF
--- a/docker/docker-cleaner-stack.yml
+++ b/docker/docker-cleaner-stack.yml
@@ -2,10 +2,13 @@ services:
   swarm_cleanup:
     image: alpine:3.19
     environment:
-      REPO_URL: "https://github.com/tanngoc93/swarm_cleanup.git"
-      REPO_DIR: "/tmp/swarm_cleanup"
-      SCRIPT: "scripts/docker_image_cleanup.sh"
+      REPO_URL: "${REPO_URL:-https://github.com/tanngoc93/swarm_cleanup.git}"
+      REPO_DIR: "${REPO_DIR:-/tmp/swarm_cleanup}"
+      SCRIPT: "${SCRIPT:-scripts/docker_image_cleanup.sh}"
       IMAGE_REPO: "${IMAGE_REPO}"
+      DRY_RUN: "${DRY_RUN:-0}"
+      RM_TIMEOUT: "${RM_TIMEOUT:-20s}"
+      RUN_AT: "${RUN_AT}"
     command: >
       sh -c "
         set -e;
@@ -14,7 +17,7 @@ services:
         rm -rf $$REPO_DIR &&
         git clone --depth=1 $$REPO_URL $$REPO_DIR;
         chmod +x $$REPO_DIR/$$SCRIPT;
-        IMAGE_REPO=$$IMAGE_REPO bash $$REPO_DIR/$$SCRIPT;
+        DRY_RUN=$$DRY_RUN RM_TIMEOUT=$$RM_TIMEOUT IMAGE_REPO=$$IMAGE_REPO bash $$REPO_DIR/$$SCRIPT;
         echo '--- Done on node: '$$(hostname);
         exit 0
       "


### PR DESCRIPTION
## Summary
- Allow tuning of cleanup behavior in docker-cleaner stack via DRY_RUN and RM_TIMEOUT vars
- Pass deployment timestamp RUN_AT so stack redeploys each run

## Testing
- `bash -n deploy_stack_with_cleanup.sh scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7fbd7d2ec832bbb20d42dc61374dc