### PR TITLE
Use /tmp for default repo clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
   IMAGE_REPO=myorg/myimage \
   STACK_NAME=my_stack \
   STACK_FILE=/root/docker/app-stack.yml \
-  ./ensure_swarm_cleanup_and_deploy.sh /root/run/swarm_cleanup main
+  ./ensure_swarm_cleanup_and_deploy.sh /tmp/swarm_cleanup main
   ```
 
 ## Development

--- a/ensure_swarm_cleanup_and_deploy.sh
+++ b/ensure_swarm_cleanup_and_deploy.sh
@@ -9,7 +9,7 @@
 # Usage:
 #   ./ensure_swarm_cleanup_and_deploy.sh [TARGET_DIR] [BRANCH]
 #
-#   TARGET_DIR (optional) : destination directory (default: $HOME/run/swarm_cleanup)
+#   TARGET_DIR (optional) : destination directory (default: /tmp/swarm_cleanup)
 #   BRANCH     (optional) : git branch to track (default: main)
 #
 # Environment variables (with sane defaults):
@@ -27,7 +27,7 @@ set -euo pipefail
 
 # -------- Config (defaults) --------
 REPO_URL="https://github.com/tanngoc93/swarm_cleanup.git"
-TARGET_DIR="${1:-$HOME/run/swarm_cleanup}"
+TARGET_DIR="${1:-/tmp/swarm_cleanup}"
 BRANCH="${2:-main}"
 
 # Deployment ENV (can be overridden by caller)


### PR DESCRIPTION
## Summary
- Default repo directory moved to `/tmp/swarm_cleanup`
- Update documentation to use `/tmp/swarm_cleanup`

## Testing
- `bash -n deploy_and_cleanup.sh manual_rollback.sh`
- `bash -n scripts/cleanup_docker_images.sh`
- `bash -n scripts/run_swarm_cleanup.sh`
- `bash -n ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b969d8c754832b9acdd59a9dbe7a95