### PR TITLE
Allow exiting manual rollback selection

### DIFF
--- a/manual_rollback.sh
+++ b/manual_rollback.sh
@@ -53,10 +53,14 @@ main() {
     for i in "${!DIGESTS[@]}"; do
       echo "$((i+1))) ${DIGESTS[$i]}"
     done
-    read -p "Select digest number: " sel
+    read -p "Select digest number (0 to exit): " sel
     if [[ -z "$sel" || ! "$sel" =~ ^[0-9]+$ ]]; then
       echo "Invalid selection" >&2
       exit 1
+    fi
+    if [[ "$sel" -eq 0 ]]; then
+      echo "Exiting without rollback."
+      exit 0
     fi
     idx=$((sel-1))
     if (( idx < 0 || idx >= ${#DIGESTS[@]} )); then
@@ -91,3 +95,5 @@ main() {
 }
 
 main "$@"
+
+exit 0


### PR DESCRIPTION
## Summary
- allow users to exit manual rollback by entering `0` at the digest prompt

## Testing
- `bash -n manual_rollback.sh`
- `shellcheck manual_rollback.sh` *(command not found)*
- `apt-get update` *(repository not signed)*
- `apt-get install -y shellcheck` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b96bdac538832bba50a7f46ad9baa1